### PR TITLE
Allow to customize Vaadin Connect base url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-devtools</artifactId>
                 <version>${spring.boot.version}</version>
                 <scope>runtime</scope>

--- a/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
+++ b/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
@@ -34,6 +34,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.vaadin.connect.VaadinConnectControllerConfiguration;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -51,6 +53,9 @@ public class VaadinConnectControllerIT {
 
   @Autowired
   private TestRestTemplate template;
+
+  @Autowired
+  private VaadinConnectControllerConfiguration vaadinConnectConfiguration;
 
   @Test
   public void simpleMethodExecutedSuccessfully() {
@@ -207,7 +212,8 @@ public class VaadinConnectControllerIT {
   }
 
   private String getRequestUrl(String serviceName, String methodName) {
-    return String.format("http://localhost:%d/%s/%s", port, serviceName,
+    return String.format("http://localhost:%d/%s/%s/%s", port,
+        vaadinConnectConfiguration.getVaadinConnectBaseUrl(), serviceName,
         methodName);
   }
 

--- a/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
+++ b/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
@@ -212,7 +212,7 @@ public class VaadinConnectControllerIT {
   }
 
   private String getRequestUrl(String serviceName, String methodName) {
-    return String.format("http://localhost:%d/%s/%s/%s", port,
+    return String.format("http://localhost:%d%s/%s/%s", port,
         vaadinConnectProperties.getVaadinConnectEndpoint(), serviceName,
         methodName);
   }

--- a/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
+++ b/vaadin-connect-demo/src/test/java/com/vaadin/connect/demo/VaadinConnectControllerIT.java
@@ -34,7 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.vaadin.connect.VaadinConnectControllerConfiguration;
+import com.vaadin.connect.VaadinConnectProperties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -55,7 +55,7 @@ public class VaadinConnectControllerIT {
   private TestRestTemplate template;
 
   @Autowired
-  private VaadinConnectControllerConfiguration vaadinConnectConfiguration;
+  private VaadinConnectProperties vaadinConnectProperties;
 
   @Test
   public void simpleMethodExecutedSuccessfully() {
@@ -213,7 +213,7 @@ public class VaadinConnectControllerIT {
 
   private String getRequestUrl(String serviceName, String methodName) {
     return String.format("http://localhost:%d/%s/%s/%s", port,
-        vaadinConnectConfiguration.getVaadinConnectBaseUrl(), serviceName,
+        vaadinConnectProperties.getVaadinConnectEndpoint(), serviceName,
         methodName);
   }
 

--- a/vaadin-connect/pom.xml
+++ b/vaadin-connect/pom.xml
@@ -17,6 +17,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectController.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectController.java
@@ -65,7 +65,8 @@ import org.springframework.web.bind.annotation.RestController;
  * parameter types should also correspond for the request to be successful.
  */
 @RestController
-@Import(VaadinConnectControllerConfiguration.class)
+@Import({ VaadinConnectControllerConfiguration.class,
+    VaadinConnectProperties.class })
 public class VaadinConnectController {
   private static final String VAADIN_SERVICE_MAPPER_BEAN_QUALIFIER = "vaadinServiceMapper";
 

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectController.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectController.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -64,6 +65,7 @@ import org.springframework.web.bind.annotation.RestController;
  * parameter types should also correspond for the request to be successful.
  */
 @RestController
+@Import(VaadinConnectControllerConfiguration.class)
 public class VaadinConnectController {
   private static final String VAADIN_SERVICE_MAPPER_BEAN_QUALIFIER = "vaadinServiceMapper";
 

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
@@ -1,0 +1,70 @@
+package com.vaadin.connect;
+
+import java.lang.reflect.Method;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * A configuration class for customizing the {@link VaadinConnectController}
+ * class.
+ */
+@Configuration
+public class VaadinConnectControllerConfiguration {
+  @Value("${vaadin.connect.base.url:/connect}")
+  private String vaadinConnectBaseUrl;
+
+  /**
+   * Customize the base url that Vaadin Connect services are located at. See
+   * default value in the
+   * {@link VaadinConnectControllerConfiguration#vaadinConnectBaseUrl} field
+   * annotation.
+   *
+   * @return base url that should be used to access any Vaadin Connect service
+   */
+  public String getVaadinConnectBaseUrl() {
+    return vaadinConnectBaseUrl;
+  }
+
+  /**
+   * Registers {@link VaadinConnectController} to use
+   * {@link VaadinConnectControllerConfiguration#getVaadinConnectBaseUrl()} as a
+   * base url for all Vaadin Connect services.
+   *
+   * @return updated configuration for {@link VaadinConnectController}
+   */
+  @Bean
+  public WebMvcRegistrations webMvcRegistrationsHandlerMapping() {
+    return new WebMvcRegistrations() {
+      @Override
+      public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+        return new RequestMappingHandlerMapping() {
+
+          @Override
+          protected void registerHandlerMethod(Object handler, Method method,
+              RequestMappingInfo mapping) {
+            if (VaadinConnectController.class
+                .equals(method.getDeclaringClass())) {
+              PatternsRequestCondition connectServicePattern = new PatternsRequestCondition(
+                getVaadinConnectBaseUrl())
+                      .combine(mapping.getPatternsCondition());
+
+              mapping = new RequestMappingInfo(mapping.getName(),
+                  connectServicePattern, mapping.getMethodsCondition(),
+                  mapping.getParamsCondition(), mapping.getHeadersCondition(),
+                  mapping.getConsumesCondition(),
+                  mapping.getProducesCondition(), mapping.getCustomCondition());
+            }
+
+            super.registerHandlerMethod(handler, method, mapping);
+          }
+        };
+      }
+    };
+  }
+}

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
@@ -2,7 +2,6 @@ package com.vaadin.connect;
 
 import java.lang.reflect.Method;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,25 +15,23 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Configuration
 public class VaadinConnectControllerConfiguration {
-  @Value("${vaadin.connect.base.url:/connect}")
-  private String vaadinConnectBaseUrl;
+  private final VaadinConnectProperties vaadinConnectProperties;
 
   /**
-   * Customize the base url that Vaadin Connect services are located at. See
-   * default value in the
-   * {@link VaadinConnectControllerConfiguration#vaadinConnectBaseUrl} field
-   * annotation.
+   * Initializes the connect configuration.
    *
-   * @return base url that should be used to access any Vaadin Connect service
+   * @param vaadinConnectProperties
+   *          Vaadin Connect properties
    */
-  public String getVaadinConnectBaseUrl() {
-    return vaadinConnectBaseUrl;
+  public VaadinConnectControllerConfiguration(
+      VaadinConnectProperties vaadinConnectProperties) {
+    this.vaadinConnectProperties = vaadinConnectProperties;
   }
 
   /**
    * Registers {@link VaadinConnectController} to use
-   * {@link VaadinConnectControllerConfiguration#getVaadinConnectBaseUrl()} as a
-   * base url for all Vaadin Connect services.
+   * {@link VaadinConnectProperties#getVaadinConnectEndpoint()} as an endpoint
+   * for all Vaadin Connect services.
    *
    * @return updated configuration for {@link VaadinConnectController}
    */
@@ -51,7 +48,7 @@ public class VaadinConnectControllerConfiguration {
             if (VaadinConnectController.class
                 .equals(method.getDeclaringClass())) {
               PatternsRequestCondition connectServicePattern = new PatternsRequestCondition(
-                getVaadinConnectBaseUrl())
+                  vaadinConnectProperties.getVaadinConnectEndpoint())
                       .combine(mapping.getPatternsCondition());
 
               mapping = new RequestMappingInfo(mapping.getName(),

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
@@ -1,0 +1,26 @@
+package com.vaadin.connect;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Class that contains all Vaadin Connect customizable properties.
+ */
+@Component
+@ConfigurationProperties("vaadin.connect")
+public class VaadinConnectProperties {
+  @Value("${vaadin.connect.endpoint:/connect}")
+  private String vaadinConnectEndpoint;
+
+  /**
+   * Customize the endpoint for all Vaadin Connect services. See default value
+   * in the {@link VaadinConnectProperties#vaadinConnectEndpoint} field
+   * annotation.
+   *
+   * @return endpoint that should be used to access any Vaadin Connect service
+   */
+  public String getVaadinConnectEndpoint() {
+    return vaadinConnectEndpoint;
+  }
+}

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("vaadin.connect")
 public class VaadinConnectProperties {
-  @Value("${vaadin.connect.endpoint:/connect}")
+  @Value("${vaadin.connect.endpoint:connect}")
   private String vaadinConnectEndpoint;
 
   /**

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectProperties.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("vaadin.connect")
 public class VaadinConnectProperties {
-  @Value("${vaadin.connect.endpoint:connect}")
+  @Value("${vaadin.connect.endpoint:/connect}")
   private String vaadinConnectEndpoint;
 
   /**


### PR DESCRIPTION
Closes #23 

Also hide all Vaadin Connect services behind `/connect` base url to avoid conflicts with other controllers, such as `oauth`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/42)
<!-- Reviewable:end -->
