### PR TITLE
Use tags description

### DIFF
--- a/vaadin-connect/src/main/resources/com/vaadin/connect/generator/ESModuleApiTemplate.mustache
+++ b/vaadin-connect/src/main/resources/com/vaadin/connect/generator/ESModuleApiTemplate.mustache
@@ -5,7 +5,7 @@ import defaultClient from './connect-client.default.js';
 {{#operations}}{{#vaadinConnectClassDescription}}
 
 /**
- * {{description}}
+ * {{vaadinConnectClassDescription}}
  */{{/vaadinConnectClassDescription}}{{/operations}}
 export class {{classname}} {
 

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/expected-openapi-custom-application-properties.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/expected-openapi-custom-application-properties.json
@@ -8,6 +8,10 @@
     "url" : "https://myhost.com/myendpoint",
     "description" : "Vaadin connect backend server"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers" : {
       "post" : {
@@ -268,11 +272,6 @@
           }
         }
       }
-    }
-  },
-  "x-vaadin-services" : {
-    "GeneratorTestClass" : {
-      "description" : "This class is used for OpenApi generator test"
     }
   }
 }

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/expected-openapi.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/expected-openapi.json
@@ -8,6 +8,10 @@
     "url" : "https://server.test",
     "description" : "Test description"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers" : {
       "post" : {
@@ -268,11 +272,6 @@
           }
         }
       }
-    }
-  },
-  "x-vaadin-services" : {
-    "GeneratorTestClass" : {
-      "description" : "This class is used for OpenApi generator test"
     }
   }
 }

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/get-operation-openapi.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/get-operation-openapi.json
@@ -8,6 +8,10 @@
     "url" : "https://myhost.com/myendpoint",
     "description" : "Vaadin connect backend server"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers" : {
       "get" : {
@@ -59,11 +63,6 @@
           }
         }
       }
-    }
-  },
-  "x-vaadin-services" : {
-    "GeneratorTestClass" : {
-      "description" : "This class is used for OpenApi generator test"
     }
   }
 }

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/multiple-tags-operation.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/multiple-tags-operation.json
@@ -8,6 +8,10 @@
     "url" : "https://myhost.com/myendpoint",
     "description" : "Vaadin connect backend server"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers" : {
       "post" : {

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/no-tag-operation.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/no-tag-operation.json
@@ -8,6 +8,10 @@
     "url" : "https://myhost.com/myendpoint",
     "description" : "Vaadin connect backend server"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers" : {
       "post" : {

--- a/vaadin-connect/src/test/resources/com/vaadin/connect/generator/wrong-input-path-openapi.json
+++ b/vaadin-connect/src/test/resources/com/vaadin/connect/generator/wrong-input-path-openapi.json
@@ -8,6 +8,10 @@
     "url" : "https://myhost.com/myendpoint",
     "description" : "Vaadin connect backend server"
   } ],
+  "tags" : [ {
+    "name" : "GeneratorTestClass",
+    "description" : "This class is used for OpenApi generator test"
+  } ],
   "paths" : {
     "/GeneratorTestClass/getAllUsers/" : {
       "post" : {
@@ -59,11 +63,6 @@
           }
         }
       }
-    }
-  },
-  "x-vaadin-services" : {
-    "GeneratorTestClass" : {
-      "description" : "This class is used for OpenApi generator test"
     }
   }
 }


### PR DESCRIPTION
Instead of using `x-vaadin-services` extension for storing javadoc of service classes, we can use [TagObject](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#tagObject) to describe the tags which has been declared in each operation.

Connect to #20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/73)
<!-- Reviewable:end -->
