### PR TITLE
m2eclipse integration

### DIFF
--- a/vaadin-connect-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/vaadin-connect-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate-openapi-spec</goal>
+          <goal>generate-vaadin-client</goal>
+          <goal>generate-connect-modules</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore></ignore>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>
+


### PR DESCRIPTION
It prevents eclipse marking the project with `Plugin execution not covered by lifecycle configuration` errors.

<img width="1599" alt="screen shot 2018-12-05 at 08 05 01" src="https://user-images.githubusercontent.com/161853/49495808-90873c00-f864-11e8-8f9c-3786a0cd4bd0.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/108)
<!-- Reviewable:end -->
