### PR TITLE
chore(generator): Remove unused logging dependency

### DIFF
--- a/vaadin-connect-maven-plugin/pom.xml
+++ b/vaadin-connect-maven-plugin/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>swagger-codegen-generators</artifactId>
             <version>1.0.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
swagger-codegen plugin's dependency brings in the logback logger
implementation and slf4j-simple implementation gets ignored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/128)
<!-- Reviewable:end -->
