### PR TITLE
chore(plugin): include javax.annotation-api into the plugin .jar

### DIFF
--- a/vaadin-connect-maven-plugin/pom.xml
+++ b/vaadin-connect-maven-plugin/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-symbol-solver-core</artifactId>
             <version>3.7.0</version>


### PR DESCRIPTION
This fixes the `java.lang.NoClassDefFoundError: javax/annotation/security/PermitAll` error that occurs when trying to use the plugin with maven 3.5.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/131)
<!-- Reviewable:end -->
