### PR TITLE
fix(frontend): use credentials after receiving invalid_token response

### DIFF
--- a/frontend/connect/src/connect-client.js
+++ b/frontend/connect/src/connect-client.js
@@ -252,8 +252,12 @@ export class ConnectClient {
         });
 
         if (tokenResponse.status === 400 || tokenResponse.status === 401) {
+          const invalidResponse = await tokenResponse.json();
+          if (invalidResponse.error === 'invalid_token') {
+            current = new AuthTokens();
+          }
           // Wrong credentials response, loop to ask again with the message
-          message = (await tokenResponse.json()).error_description;
+          message = invalidResponse.error_description;
         } else {
           assertResponseIsOk(tokenResponse);
           // Successful token response

--- a/frontend/connect/test/connect-client.spec.js
+++ b/frontend/connect/test/connect-client.spec.js
@@ -433,6 +433,33 @@ describe('ConnectClient', () => {
           body = new URLSearchParams(body);
           expect(body.get('grant_type')).to.be.equal('password');
         });
+
+        it('should not use refreshToken if getting invalid_token response', async() => {
+          localStorage.setItem('vaadin.connect.refreshToken', generateOAuthJson().refresh_token);
+          fetchMock.restore();
+
+          fetchMock
+            .post(client.tokenEndpoint,
+              {body: {error: 'invalid_token', error_description: 'Cannot convert access token to JSON'}, status: 401},
+              {repeat: 1})
+            .post(client.tokenEndpoint, generateOAuthJson,
+              {repeat: 1, overwriteRoutes: false})
+            .post(vaadinEndpoint, {fooData: 'foo'});
+
+          const newClient = new ConnectClient({credentials: client.credentials});
+          await newClient.call('FooService', 'fooMethod');
+
+          expect(newClient.credentials).to.be.calledOnce;
+          expect(fetchMock.calls().length).to.be.equal(3);
+
+          let [, {body}] = fetchMock.calls()[0];
+          body = new URLSearchParams(body);
+          expect(body.get('grant_type')).to.be.equal('refresh_token');
+
+          [, {body}] = fetchMock.calls()[1];
+          body = new URLSearchParams(body);
+          expect(body.get('grant_type')).to.be.equal('password');
+        });
       });
 
       describe('with {requireCredentials: false} option', () => {


### PR DESCRIPTION
Fix #102

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/133)
<!-- Reviewable:end -->
