### PR TITLE
fix(demo): ensure clean backend shutdown on shell termination

### DIFF
--- a/vaadin-connect-demo/scripts/start/backend.js
+++ b/vaadin-connect-demo/scripts/start/backend.js
@@ -41,6 +41,12 @@ const [chainedExecutable, ...chainedArgs] = endOfOptionsIndex > -1
   ? process.argv.slice(endOfOptionsIndex + 1)
   : [];
 
+// Graceful shutdown
+process.on('SIGINT', () => process.exit(0));
+process.on('SIGBREAK', () => process.exit(0));
+process.on('SIGHUP', () => process.exit(129));
+process.on('SIGTERM', () => process.exit(137));
+
 // Generator
 const hasFilesWithExtension = (directory, extension) => {
   return fs.existsSync(directory)


### PR DESCRIPTION
When closing the terminal running `$ npm start`, I want all spawned
processes to be shutdown.

Without the fix, the forkend Java backend application process keeps
running after the terminal shutdown.