### PR TITLE
fix(generator): use project class path for type resolving in OpenAPI generator

### DIFF
--- a/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoVaadinService.java
+++ b/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoVaadinService.java
@@ -11,8 +11,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.Version;
 
 import com.vaadin.connect.VaadinService;
+import com.vaadin.connect.demo.account.BeanWithTypeFromDependencies;
 import com.vaadin.connect.oauth.AnonymousAllowed;
 
 @VaadinService
@@ -61,6 +63,20 @@ public class DemoVaadinService {
   @RolesAllowed("ROLE_USER")
   public int addOne(int number) {
     return number + 1;
+  }
+
+  /**
+   * This method is to make sure that the generator won't fail the build when
+   * resolving types from project's dependencies.
+   *
+   * @param version
+   *          a version object from dependencies
+   *
+   * @return {@code null}
+   */
+  @PermitAll
+  public BeanWithTypeFromDependencies testTypeResolverMethod(Version version) {
+    return null;
   }
 
   @PermitAll

--- a/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/account/BeanWithTypeFromDependencies.java
+++ b/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/account/BeanWithTypeFromDependencies.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.connect.demo.account;
+
+import com.fasterxml.jackson.core.Version;
+
+/**
+ * A test bean which has a field with type from project's dependencies. This
+ * class is to make sure that the generator won't fail the build when resolving
+ * types from project's dependencies.
+ */
+public class BeanWithTypeFromDependencies {
+  Version version;
+  Account account;
+}

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/OpenApiSpecGeneratorMojo.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/OpenApiSpecGeneratorMojo.java
@@ -55,7 +55,9 @@ public class OpenApiSpecGeneratorMojo extends VaadinConnectMojoBase {
       new OpenApiSpecGenerator(readApplicationProperties()).generateOpenApiSpec(
           sourcesPaths, jarPaths, openApiJsonFile.toPath());
     } catch (DependencyResolutionRequiredException e) {
-      throw new IllegalStateException(e);
+      throw new IllegalStateException(
+          "All dependencies need to be resolved before running the OpenAPI spec generator. Please resolve the dependencies and try again.",
+          e);
     }
   }
 }

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiParser.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiParser.java
@@ -121,8 +121,8 @@ class OpenApiParser {
   }
 
   /**
-   * Add jar paths to help the symbol resolver resolves types in jar
-   * dependencies.
+   * Adds a jar path information to use when resolving the type used in a
+   * project from that jar
    * 
    * @param jarPath
    *          path of the jar
@@ -181,7 +181,9 @@ class OpenApiParser {
         combinedTypeSolver.add(new JarTypeSolver(jarPath));
       }
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      throw new UncheckedIOException(
+          "I/O error happens when reading jar files. Please make sure that dependencies' jar files are accessible.",
+          e);
     }
     return new ParserConfiguration()
         .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver));
@@ -456,7 +458,7 @@ class OpenApiParser {
       return parseResolvedTypeToSchema(javaType.resolve());
     } catch (Exception e) {
       LoggerFactory.getLogger(OpenApiParser.class).info(String.format(
-          "Can't resolve type %s for creating custom OpenAPI Schema. Use the default ObjectSchema instead.",
+          "Can't resolve type '%s' for creating custom OpenAPI Schema. Using the default ObjectSchema instead.",
           javaType.asString()), e);
     }
     return new ObjectSchema();

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
@@ -86,15 +86,14 @@ public class OpenApiSpecGenerator {
    *
    * @param sourcesPaths
    *          the source root to be analyzed
-   * @param jarPaths
-   *          jar paths information to use when resolving the types used in a
-   *          project from those jars
+   * @param classLoader
+   *          the ClassLoader which is able to load the classes in sourcesPaths
    * @param specOutputFile
    *          the target file to write the generation output to
    */
   public void generateOpenApiSpec(Collection<Path> sourcesPaths,
-      Collection<String> jarPaths, Path specOutputFile) {
-    jarPaths.forEach(generator::addJarPath);
+      ClassLoader classLoader, Path specOutputFile) {
+    generator.setTypeResolverClassLoader(classLoader);
     generateOpenApiSpec(sourcesPaths, specOutputFile);
   }
 

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
@@ -81,6 +81,23 @@ public class OpenApiSpecGenerator {
     GeneratorUtils.writeToFile(specOutputFile, Json.pretty(openAPI));
   }
 
+  /**
+   * Generates the open api spec file based on the sources provided.
+   *
+   * @param sourcesPaths
+   *          the source root to be analyzed
+   * @param jarPaths
+   *          the jar paths which help the parser resolves the types in those
+   *          jar dependencies
+   * @param specOutputFile
+   *          the target file to write the generation output to
+   */
+  public void generateOpenApiSpec(Collection<Path> sourcesPaths,
+      Collection<String> jarPaths, Path specOutputFile) {
+    jarPaths.forEach(generator::addJarPath);
+    generateOpenApiSpec(sourcesPaths, specOutputFile);
+  }
+
   private OpenApiConfiguration extractOpenApiConfiguration(
       Properties applicationProperties) {
     String endpoint = applicationProperties.getProperty(ENDPOINT,

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiSpecGenerator.java
@@ -64,7 +64,7 @@ public class OpenApiSpecGenerator {
   }
 
   /**
-   * Generates the open api spec file based on the sources provided.
+   * Generates the OpenAPI spec file based on the sources provided.
    *
    * @param sourcesPaths
    *          the source root to be analyzed
@@ -82,13 +82,13 @@ public class OpenApiSpecGenerator {
   }
 
   /**
-   * Generates the open api spec file based on the sources provided.
+   * Generates the OpenAPI spec file based on the sources provided.
    *
    * @param sourcesPaths
    *          the source root to be analyzed
    * @param jarPaths
-   *          the jar paths which help the parser resolves the types in those
-   *          jar dependencies
+   *          jar paths information to use when resolving the types used in a
+   *          project from those jars
    * @param specOutputFile
    *          the target file to write the generation output to
    */

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/collectionservice/CollectionTestService.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/collectionservice/CollectionTestService.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.connect.plugin.generator.collectionservice;
 
-import com.vaadin.connect.VaadinService;
-
 import java.util.ArrayList;
+
+import com.vaadin.connect.VaadinService;
 
 @VaadinService
 public class CollectionTestService {


### PR DESCRIPTION
Fix #209 
Fix #208

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/211)
<!-- Reviewable:end -->
