### PR TITLE
doc(general): add a README file with a table of contents

### DIFF
--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -9,8 +9,8 @@ Vaadin Connect is a Vaadin Labs experiment with a secure stateless communication
 
 = Table of contents
 
-** <<default-client#,Vaadin Connect JavaScript client>>
-** <<security#,Security in Vaadin Connect>>
-** <<javascript-generator#,JavaScript wrappers for `@VaadinService` Java classes>>
-** <<type-conversion#,Type conversion between JavaScript and Java>>
 ** <<vaadin-connect-maven-plugin#,Building a Vaadin Connect app with `vaadin-connect-maven-plugin`>>
+** <<security#,Security in Vaadin Connect>>
+** <<javascript-generator#,Generating JavaScript wrappers for `@VaadinService` Java classes>>
+** <<default-client#,Vaadin Connect JavaScript client>>
+** <<type-conversion#,Type conversion between JavaScript and Java>>

--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -4,6 +4,9 @@ order: 1
 layout: page
 ---
 
+[NOTE]
+Vaadin Connect is a Vaadin Labs experiment with a secure stateless communication framework. To see a working sample project check out the https://github.com/vaadin/base-starter-connect[base-starter-connect] repo.
+
 = Table of contents
 
 ** <<default-client#,Vaadin Connect JavaScript client>>

--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -1,0 +1,13 @@
+---
+title: Table of Contents
+order: 1
+layout: page
+---
+
+= Table of contents
+
+** <<default-client#,Vaadin Connect JavaScript client>>
+** <<security#,Security in Vaadin Connect>>
+** <<javascript-generator#,JavaScript wrappers for `@VaadinService` Java classes>>
+** <<type-conversion#,Type conversion between JavaScript and Java>>
+** <<vaadin-connect-maven-plugin#,Building a Vaadin Connect app with `vaadin-connect-maven-plugin`>>

--- a/doc/security.asciidoc
+++ b/doc/security.asciidoc
@@ -1,4 +1,3 @@
-
 ---
 title: Security
 order: 800

--- a/doc/vaadin-connect-maven-plugin.asciidoc
+++ b/doc/vaadin-connect-maven-plugin.asciidoc
@@ -1,4 +1,3 @@
-
 ---
 title: Vaadin Connect Maven plugin
 order: 799


### PR DESCRIPTION
Since the docs are not deployed anywhere yet, let's optimize them for GitHub:
 - add a `README` file (not e.g. `Overivew`) because GitHub renders it automatically under the directory contents listing
 - collect links to all existing documentation pages in one place so that there is a single link to all Vaadin Connect docs (and it can be shared with someone who is interested to try it out)
 - include a link to the starter project into the same README file

This is a prerequisite for starting DX tests, because any tester would need a single entry point into the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/224)
<!-- Reviewable:end -->
