### PR TITLE
test(e2e): add tests for loading static resources

### DIFF
--- a/vaadin-connect-demo/e2e/demo.spec.js
+++ b/vaadin-connect-demo/e2e/demo.spec.js
@@ -102,6 +102,14 @@ describe('demo application', () => {
 
   describe('single page application', () => {
 
+    it('should get index when url is root', async(context) => {
+      const page = context.remote.get('');
+      await page
+        .findById('number').getVisibleText().then(text =>
+          expect(text).to.equal('1')
+        );
+    });
+
     it('should get index when url has .html extension', async(context) => {
       const page = context.remote.get('app/anypage.html');
       await page
@@ -123,6 +131,14 @@ describe('demo application', () => {
       await page
         .findByCssSelector('body').getVisibleText().then(text =>
           expect(text).to.match(/error/i)
+        );
+    });
+
+    it('should load static resource when it exists', async(context) => {
+      const page = context.remote.get('README.txt');
+      await page
+        .findByCssSelector('body').getVisibleText().then(text =>
+          expect(text).to.match(/README content/i)
         );
     });
   });

--- a/vaadin-connect-demo/e2e/demo.spec.js
+++ b/vaadin-connect-demo/e2e/demo.spec.js
@@ -110,8 +110,8 @@ describe('demo application', () => {
         );
     });
 
-    it('should get index when url has .html extension', async(context) => {
-      const page = context.remote.get('app/anypage.html');
+    it('should get index when url has no extension', async(context) => {
+      const page = context.remote.get('app/anyroute');
       await page
         .findById('number').getVisibleText().then(text =>
           expect(text).to.equal('1')

--- a/vaadin-connect-demo/static/README.txt
+++ b/vaadin-connect-demo/static/README.txt
@@ -1,0 +1,1 @@
+README content


### PR DESCRIPTION
Fix #180 
- `a <a href="users"> link works correctly in both cases` => this has been skipped since it depends on #179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/237)
<!-- Reviewable:end -->
