### PR TITLE
review comments and suggestions

### DIFF
--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -87,15 +87,12 @@ Web Token access token containg the information about the user.
 This enables easy cluster backend deployments, as there is no need to manage a
 shared session storage between multiple backend servers.
 
-=== Vaadin components
+=== Works with any UI framework
 
-The frontend part in the `base-starter-connect` Vaadin Connect example
-application is using Vaadin components, as well as provides support for
-third-party and community Web Components:
+TODO (rewrite to highlight these points):
 
-- Uses `npm` for frontend package management.
-- Includes the `@webcomponents/webcomponentsjs` polyfill.
-- Provides ES modules support with bundling (more on that below).
+ - Vaadin Connect is UI framework-agnostic and can be used with React, Angular, etc.
+ - The base starter gives an example of using it with vanilla JS and Vaadin Components.
 
 === Modern ES6 / ES2017 based frontend
 

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -12,8 +12,7 @@ toc::[]
 
 == What is Vaadin Connect
 
-Vaadin Connect is a bridge between stateless Java backend services and Single
-Page Application frontend.
+Vaadin Connect is a bridge between stateless Java backend services and a JavaScript frontend.
 
 The Vaadin Connect collection of tools and libraries includes:
 
@@ -30,8 +29,7 @@ image::simplified-rpc-sequence.svg[opts=inline]
 
 === Java backend, JavaScript frontend
 
-Vaadin Connect implies using Java on the backend, and building the fronted as a
-JavaScript single-page application.
+Vaadin Connect implies using Java on the backend, and building the fronted using JavaScript.
 
 === Generated JavaScript RPC services client
 

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -51,16 +51,14 @@ The current version of the `vaadin-connect` Java library is implemented using li
 
 == Why use Vaadin Connect?
 
-=== Java backend, JavaScript frontend
+Vaadin Connect gives a _"better than REST"_ experience for the development teams that use Java on the backend, and JavaScript on the fronted.
 
-Vaadin Connect implies using Java on the backend, and building the fronted using JavaScript.
-
-=== Generated JavaScript RPC services client
+=== Type-checkable API access from JavaScript
 
 Vaadin Connect uses Java service classes code to generate a JavaScript frontend
 counterparts. The key benefits of this approach are:
 
-- Easy to use RPC. No manual network requests to API endpoints needed, instead
+- Easy to access the API. No manual REST network requests to API endpoints needed, instead
   there are generated async JavaScript methods to call.
 - Automatic JSON serialization and parsing. Vaadin Connect supports builtin Java
   data types and Beans.

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -16,14 +16,16 @@ Vaadin Connect is a bridge between stateless Java backend services and a JavaScr
 
 The Vaadin Connect collection of tools and libraries includes:
 
-- `vaadin-connect` Java library for developing stateless backend services, based
-  on Spring Boot.
+- `vaadin-connect` Java library for developing stateless backend services (based on the Servlet API v3).
 - `@vaadin/connect` JavaScript (ES Module) client library.
 - `vaadin-connect-maven-plugin` Maven plugin.
 - `base-starter-connect` example application project.
 
 .Simplified Vaadin Connect RPC sequence diagram
 image::simplified-rpc-sequence.svg[opts=inline]
+
+[NOTE]
+The current version of the `vaadin-connect` Java library is implemented using link:https://spring.io/projects/spring-framework[Spring].
 
 == Why use Vaadin Connect?
 

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -13,6 +13,31 @@ toc::[]
 == What is Vaadin Connect
 
 Vaadin Connect is a bridge between stateless Java backend services and a JavaScript frontend.
+It includes a REST server and generates JavaScript REST clients to call the Java backend in a type-checkable way.
+Security is built-in by default.
+
+[source,java]
+.DateService.java
+----
+@VaadinService
+public class DateService {
+    public int getDayOfYear(LocalDate date) {
+        return date.getDayOfYear();
+    }
+}
+----
+
+[source,js]
+.app.js
+----
+import {getDayOfYear} from './generated/DateService.js';
+
+const dayOfYear = await getDayOfYear(new Date());
+----
+
+
+.Simplified Vaadin Connect RPC sequence diagram
+image::simplified-rpc-sequence.svg[opts=inline]
 
 The Vaadin Connect collection of tools and libraries includes:
 
@@ -20,9 +45,6 @@ The Vaadin Connect collection of tools and libraries includes:
 - `@vaadin/connect` JavaScript (ES Module) client library.
 - `vaadin-connect-maven-plugin` Maven plugin.
 - `base-starter-connect` example application project.
-
-.Simplified Vaadin Connect RPC sequence diagram
-image::simplified-rpc-sequence.svg[opts=inline]
 
 [NOTE]
 The current version of the `vaadin-connect` Java library is implemented using link:https://spring.io/projects/spring-framework[Spring].

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -1,10 +1,14 @@
-
+---
 title: Getting Started
 order: 790
 layout: page
 ---
 
 = Getting Started
+:toc: macro
+:toc-placement: preamble
+
+toc::[]
 
 == What is Vaadin Connect
 


### PR DESCRIPTION
- remove mentions of SPA
   Vaadin Connect supports SPAs but does not require that the frontend is necessarily an SPA.
- remove a hard dependency on Spring
   Spring is an implementation detail. Vaadin Connect should not use anything Spring-dependent in the public APIs, nor explicitly mention it in the documentation. It's OK to tell that the current version of Connect is implemented using Spring, but that should be kept as an implementation detail that could possibly change (without changing what Connect is).
- add a code snippet to show on the first screen
   A picture tells a thousand words, and a code snippet is like a picture.
In my mind it is important to show a code snippet on the first screen of the 'What is Vaadin Connect' section.
- update the 'Why use Vaadin Connect' section
   - 'Java backend, JavaScript frontend' is not a reason by itself. I'd suggest use the content of that bullet point as the general intro for the entire 'Why' section.
   - the value of having a generated RPC client can be made more clear (e.g. by stressing the possibility to check types in JS)
- remove / rewrite the 'Vaadin Components' section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/243)
<!-- Reviewable:end -->
