### PR TITLE
fix a typo in doc/README

### DIFF
--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -9,7 +9,7 @@ Vaadin Connect is a Vaadin Labs experiment with a secure stateless communication
 
 = Table of contents
 
-** <<vaadin-connect-exceptions#,Vaadin Connect Exceptions>
+** <<vaadin-connect-exceptions#,Vaadin Connect Exceptions>>
 ** <<vaadin-connect-maven-plugin#,Building a Vaadin Connect app with `vaadin-connect-maven-plugin`>>
 ** <<security#,Security in Vaadin Connect>>
 ** <<javascript-generator#,Generating JavaScript wrappers for `@VaadinService` Java classes>>


### PR DESCRIPTION
add a missing `>` to fix the `Vaadin Connect Exceptions` link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/247)
<!-- Reviewable:end -->
