### PR TITLE
fix a typo in the JSDoc format

### DIFF
--- a/frontend/connect/src/connect-client.js
+++ b/frontend/connect/src/connect-client.js
@@ -312,7 +312,7 @@ export class ConnectClient {
    * @param {string} method Method name to call in the service class.
    * @param {Object=} params Optional object to be send in JSON request body.
    * @param {Object=} options Optional client options for this call.
-   * @param {boolean=true} options.requireCredentials Require authorization.
+   * @param {boolean} [options.requireCredentials=true] Require authorization.
    * @returns {} Decoded JSON response data.
    */
   async call(service, method, params, options = {}) {


### PR DESCRIPTION
This fixes the error reported by running the [`jsdoc`](http://usejsdoc.org/) JSDoc comments processing tool on the project sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/283)
<!-- Reviewable:end -->
