### PR TITLE
partial fix(generator): use correct TS array type for method parameters

### DIFF
--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
@@ -76,7 +76,7 @@ public class VaadinConnectTsGenerator extends DefaultCodegenConfig {
   private static final String BOOLEAN_TYPE = "boolean";
   private static final String STRING_TYPE = "string";
   private static final String OBJECT_TYPE = "object";
-  private static final String ARRAY_TYPE = "array";
+  private static final String ARRAY_TYPE = "any[]";
   private static final String BOXED_ARRAY_TYPE = "Array";
   private static final String EXTENSION_VAADIN_CONNECT_PARAMETERS = "x-vaadin-connect-parameters";
   private static final String EXTENSION_VAADIN_CONNECT_SHOW_TSDOC = "x-vaadin-connect-show-tsdoc";
@@ -141,11 +141,11 @@ public class VaadinConnectTsGenerator extends DefaultCodegenConfig {
         Arrays.asList("String", "Boolean", "Number", BOXED_ARRAY_TYPE, "Object",
             "Date", "File", "Blob"));
 
-    instantiationTypes.put(ARRAY_TYPE, BOXED_ARRAY_TYPE);
+    instantiationTypes.put("array", BOXED_ARRAY_TYPE);
     instantiationTypes.put("list", BOXED_ARRAY_TYPE);
     instantiationTypes.put("map", "Object");
     typeMapping.clear();
-    typeMapping.put(ARRAY_TYPE, ARRAY_TYPE);
+    typeMapping.put("array", ARRAY_TYPE);
     typeMapping.put("map", OBJECT_TYPE);
     typeMapping.put("List", ARRAY_TYPE);
     typeMapping.put(BOOLEAN_TYPE, BOOLEAN_TYPE);

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-default-class-no-tag.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-default-class-no-tag.ts
@@ -6,6 +6,6 @@ import client from './connect-client.default.js';
  *
  * Return list of users
  */
-export function getAllUsers(): Promise<array> {
+export function getAllUsers(): Promise<any[]> {
   return client.call('GeneratorTestClass', 'getAllUsers', undefined, {requireCredentials: false});
 }

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-first-class-multiple-tags.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-first-class-multiple-tags.ts
@@ -6,6 +6,6 @@ import client from './connect-client.default.js';
  *
  * Return list of users
  */
-export function getAllUsers(): Promise<array> {
+export function getAllUsers(): Promise<any[]> {
   return client.call('GeneratorTestClass', 'getAllUsers', undefined, {requireCredentials: false});
 }

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-multiple-lines-description.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-multiple-lines-description.ts
@@ -14,6 +14,6 @@ import client from './connect-client.default.js';
  *
  * Return list of users
  */
-export function getAllUsers(): Promise<array> {
+export function getAllUsers(): Promise<any[]> {
   return client.call('GeneratorTestClass', 'getAllUsers', undefined, {requireCredentials: false});
 }

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-second-class-multiple-tags.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-second-class-multiple-tags.ts
@@ -6,6 +6,6 @@ import client from './connect-client.default.js';
  *
  * Return list of users
  */
-export function getAllUsers(): Promise<array> {
+export function getAllUsers(): Promise<any[]> {
   return client.call('GeneratorTestClass', 'getAllUsers', undefined, {requireCredentials: false});
 }

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/collectionservice/expected-CollectionService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/collectionservice/expected-CollectionService.ts
@@ -18,6 +18,6 @@ export function getCollectionByAuthor(
  *
  * Return list of user name
  */
-export function getListOfUserName(): Promise<array> {
+export function getListOfUserName(): Promise<any[]> {
   return client.call('CollectionService', 'getListOfUserName');
 }

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-JsonTestService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-JsonTestService.ts
@@ -75,7 +75,7 @@ export function getAllUserRolesMap(): Promise<object> {
  *
  * Return list of users
  */
-export function getAllUsers(): Promise<array> {
+export function getAllUsers(): Promise<any[]> {
   return client.call('JsonTestService', 'getAllUsers');
 }
 
@@ -87,7 +87,7 @@ export function getAllUsers(): Promise<array> {
  */
 export function getArrayInt(
   input: array
-): Promise<array> {
+): Promise<any[]> {
   return client.call('JsonTestService', 'getArrayInt', {input}, {requireCredentials: false});
 }
 


### PR DESCRIPTION
`array` is not a valid type in TS. At the very least, it should be either `Array<any>` or `any[]`, and preferably, it should also include the type information of the array items (e.g. `Array<number>` or `number[]`).

This is a partial fix for #312. It only fixes the generated type of method parameters (generate `any[]` instead of `array`). The type of the return values is still generated wrongly.

Related to #312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/313)
<!-- Reviewable:end -->
