### PR TITLE
fix: drop .ts extensions in the imports

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -23,7 +23,7 @@ public class DateService {
 [source,typescript]
 .app.ts
 ----
-import * as dateService from './generated/DateService.js';
+import * as dateService from './generated/DateService';
 
 showDayOfYearButton.onclick = async() => {
   const dayOfYear: number = await dateService.getDayOfYear(new Date());

--- a/doc/client-middleware.asciidoc
+++ b/doc/client-middleware.asciidoc
@@ -76,7 +76,7 @@ To use a middleware, when the Vaadin Connect client is instantiated, include you
 [source, typescript]
 ----
 import {ConnectClient} from '@vaadin/connect';
-import {MyLogMiddleware} from './my-log-middleware.ts';
+import {MyLogMiddleware} from './my-log-middleware';
 
 const client = new ConectClient({
   endpoint: '/connect',
@@ -91,8 +91,8 @@ Alternatively, you can modify the `middlewares` array property on the existing c
 .index.ts
 [source, typescript]
 ----
-import client from './generated/connect-client.default.ts';
-import {MyLogMiddleware} from './my-log-middleware.ts';
+import client from './generated/connect-client.default';
+import {MyLogMiddleware} from './my-log-middleware';
 
 client.middlewares = [MyLogMiddleware];
 ----

--- a/doc/default-client.asciidoc
+++ b/doc/default-client.asciidoc
@@ -78,7 +78,7 @@ When all the Vaadin Connect plugin generation goals are used, the service method
 [source, typescript]
 [[generated-module]]
 ----
-import {* as singleService} from './generated/SingleService.ts';
+import * as singleService from './generated/SingleService';
 
 (async() => {
   await singleService.customMethod(4);
@@ -93,7 +93,7 @@ If only the default client is generated, it can be used to access the Vaadin Con
 [source, typescript]
 [[generated-client]]
 ----
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 
 (async() => {
   await client.call('SingleService', 'customMethod', {number: 4});

--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -147,7 +147,7 @@ Then, add the following to the beginning of `frontend/index.ts`:
 
 [source,typescript]
 ----
-import * as counterService from './generated/CounterService.ts';
+import * as counterService from './generated/CounterService';
 
 const counter = document.getElementById('counter') as HTMLInputElement;
 document.getElementById('addOne').onclick = async() => {

--- a/doc/how-to-add-login-form.asciidoc
+++ b/doc/how-to-add-login-form.asciidoc
@@ -57,7 +57,7 @@ Vaadin Connect `client` inspects service callbacks, when it realizes that there 
 [source,typescript]
 ----
 
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 
 client.credentials = (options) => {
   vaadinLoginOverlay.opened = true;
@@ -92,7 +92,7 @@ You can check whether users are authenticated the first time they visit the appl
 ----
 
 import '@vaadin/vaadin-login/vaadin-login-overlay.js';
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 
 const vaadinLoginOverlay = document.querySelector('vaadin-login-overlay')
   as any;
@@ -125,7 +125,7 @@ You might be interested to remove authentication tokens from browser in order to
 
 [source,typescript]
 ----
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 
 const logout = document.getElementById('logout');
 logout.addEventListener('click', e => client.logout());

--- a/doc/how-to-create-spa.asciidoc
+++ b/doc/how-to-create-spa.asciidoc
@@ -128,8 +128,8 @@ Replace the content in your `index.ts` with the following code
 [source,typescript]
 ----
 import {Router} from '@vaadin/router';
-import './home-view.ts';
-import './user-view.ts';
+import './home-view';
+import './user-view';
 
 const outlet = document.getElementById('outlet');
 const router = new Router(outlet);

--- a/doc/how-to-use-an-api-endpoint.asciidoc
+++ b/doc/how-to-use-an-api-endpoint.asciidoc
@@ -33,7 +33,7 @@ For example, the generated ES module for the Java service defined in <<how-to-ad
  * @module CounterService
  */
 
-import client from './connect-client.default.ts';
+import client from './connect-client.default';
 
 /**
  * A method that adds one to the argument.
@@ -61,7 +61,7 @@ All the methods in the generated modules are exported so you can either import t
 [source,typescript]
 ----
 // Other imports
-import * as counterService from './generated/CounterService.ts';
+import * as counterService from './generated/CounterService';
 
 // Other code
 counterService.addOne(1).then(result => console.log(result));
@@ -71,7 +71,7 @@ counterService.addOne(1).then(result => console.log(result));
 [source,typescript]
 ----
 // Other imports
-import {addOne} from './generated/CounterService.ts';
+import {addOne} from './generated/CounterService';
 
 // Other code
 addOne(1).then(result => console.log(result));

--- a/doc/security.asciidoc
+++ b/doc/security.asciidoc
@@ -45,7 +45,7 @@ This demo shows how to automatically login to the app with hardcoded credentials
 
 [source,typescript]
 ----
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 client.credentials = (options = {}) => {
   return {username: 'test_login', password: 'test_password', stayLoggedIn: true};
 };
@@ -66,7 +66,7 @@ Username: <input id="password"type="password">
 
 [source,typescript]
 ----
-import client from './generated/connect-client.default.ts';
+import client from './generated/connect-client.default';
 
 const username = document.getElementById('username') as HTMLInputElement;
 const password = document.getElementById('password') as HTMLInputElement;

--- a/doc/typescript-generator.asciidoc
+++ b/doc/typescript-generator.asciidoc
@@ -24,7 +24,7 @@ A simple generated TypeScript files will look like the following snippet:
  *
  * This module has been generated from UserService.java
  */
-import client from './connect-client.default.ts';
+import client from './connect-client.default';
 
 /**
  * Check if a user is admin or not.

--- a/frontend/connect/src/index.ts
+++ b/frontend/connect/src/index.ts
@@ -1,2 +1,2 @@
-import './connect-meta.js';
-export * from './connect-client.js';
+import './connect-meta';
+export * from './connect-client';

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/VaadinConnectMojoBase.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/VaadinConnectMojoBase.java
@@ -40,7 +40,7 @@ public abstract class VaadinConnectMojoBase extends AbstractMojo {
   private static final Logger log = LoggerFactory
       .getLogger(VaadinConnectMojoBase.class);
 
-  public static final String DEFAULT_GENERATED_CONNECT_CLIENT_IMPORT_PATH = "./connect-client.default.js";
+  public static final String DEFAULT_GENERATED_CONNECT_CLIENT_IMPORT_PATH = "./connect-client.default";
   public static final String DEFAULT_GENERATED_CONNECT_CLIENT_NAME = "connect-client.default.ts";
   public static final String DEFAULT_CONNECT_CLIENT_PATH_PROPERTY = "vaadin.connect.connect-client.path";
   public static final String DEFAULT_CONVENTIONAL_CONNECT_CLIENT_PATH = "frontend/connect-client.js";

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
@@ -212,9 +212,17 @@ public class VaadinConnectTsGenerator extends DefaultCodegenConfig {
     generate(configurator);
   }
 
+  private static String removeTsExtension(String path) {
+    if (path.endsWith(".ts")) {
+      return path.substring(0, path.length() - 3);
+    }
+    return path;
+  }
+
   private static String getDefaultClientPath(String path) {
-    return ObjectUtils.defaultIfNull(path,
-        DEFAULT_GENERATED_CONNECT_CLIENT_IMPORT_PATH);
+    path = ObjectUtils
+        .defaultIfNull(path, DEFAULT_GENERATED_CONNECT_CLIENT_IMPORT_PATH);
+    return removeTsExtension(path);
   }
 
   private static void generate(CodegenConfigurator configurator) {

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-FooBarService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-FooBarService.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  *

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-default-class-no-tag.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-default-class-no-tag.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Get all users

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-first-class-multiple-tags.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-first-class-multiple-tags.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Get all users

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-multiple-lines-description.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-multiple-lines-description.ts
@@ -7,7 +7,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Get all users

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-no-tsdoc.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-no-tsdoc.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 export function getAllUsers(): Promise<void> {
   return client.call('GeneratorTestClass', 'getAllUsers', undefined, {requireCredentials: false});

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-partly-tsdoc.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-partly-tsdoc.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  *

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-second-class-multiple-tags.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/openapi/expected-second-class-multiple-tags.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Get all users

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/collectionservice/expected-CollectionService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/collectionservice/expected-CollectionService.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Get a collection by author name. The generator should not mix this type with the Java's Collection type.

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/denyall/expected-DenyAllService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/denyall/expected-DenyAllService.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 export function shouldBeDisplayed1(): Promise<void> {
   return client.call('DenyAllService', 'shouldBeDisplayed1');

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-GeneratorAnonymousAllowedTestClass.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-GeneratorAnonymousAllowedTestClass.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 export function anonymousAllowed(): Promise<void> {
   return client.call('customName', 'anonymousAllowed', undefined, {requireCredentials: false});

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-JsonTestService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/json/expected-JsonTestService.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore
-import client from './connect-client.default.js';
+import client from './connect-client.default';
 
 /**
  * Object with unknown structure


### PR DESCRIPTION
It turns out, using explicit "*.ts" ending in imports errors in the compiler with: `error TS2691: An import path cannot end with a '.ts' extension. Consider importing './x' instead.`.

In curtain cases (only tsc, no webpack) we could use ".js" imports instead, but then Webpack is unhappy, because it cannot resolve a missing .js file import.

Dropping .ts extensions in all the imports seems to be the most consistent way, both Webpack and tsc support that.

Depends on #314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/315)
<!-- Reviewable:end -->