### PR TITLE
make the built-in auth server optional

### DIFF
--- a/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoApplication.java
+++ b/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoApplication.java
@@ -19,7 +19,7 @@ import com.vaadin.frontend.server.EnableVaadinFrontendServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import com.vaadin.connect.oauth.EnableVaadinConnectOAuthServer;
+import com.vaadin.connect.auth.server.EnableVaadinConnectOAuthServer;
 
 /**
  * Main class of the Vaadin connect demo module.

--- a/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoVaadinService.java
+++ b/vaadin-connect-demo/src/main/java/com/vaadin/connect/demo/DemoVaadinService.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.core.Version;
 import com.vaadin.connect.VaadinConnectException;
 import com.vaadin.connect.VaadinService;
 import com.vaadin.connect.demo.account.BeanWithTypeFromDependencies;
-import com.vaadin.connect.oauth.AnonymousAllowed;
+import com.vaadin.connect.auth.AnonymousAllowed;
 
 @VaadinService
 @DenyAll

--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiObjectGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/OpenApiObjectGenerator.java
@@ -91,7 +91,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.connect.VaadinService;
 import com.vaadin.connect.VaadinServiceNameChecker;
-import com.vaadin.connect.oauth.AnonymousAllowed;
+import com.vaadin.connect.auth.AnonymousAllowed;
 
 /**
  * Java parser class which scans for all {@link VaadinService} classes and

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/AbstractServiceGenerationTest.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/AbstractServiceGenerationTest.java
@@ -65,8 +65,8 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.connect.VaadinService;
-import com.vaadin.connect.oauth.AnonymousAllowed;
-import com.vaadin.connect.oauth.VaadinConnectOAuthAclChecker;
+import com.vaadin.connect.auth.AnonymousAllowed;
+import com.vaadin.connect.auth.VaadinConnectAccessChecker;
 import com.vaadin.connect.plugin.TestUtils;
 import com.vaadin.connect.plugin.generator.OpenApiConfiguration;
 import com.vaadin.connect.plugin.generator.OpenApiObjectGenerator;
@@ -86,7 +86,7 @@ public abstract class AbstractServiceGenerationTest {
       Number.class, byte.class, char.class, short.class, int.class, long.class,
       float.class, double.class);
 
-  private static final VaadinConnectOAuthAclChecker securityChecker = new VaadinConnectOAuthAclChecker();
+  private static final VaadinConnectAccessChecker accessChecker = new VaadinConnectAccessChecker();
 
   @Rule
   public TemporaryFolder outputDirectory = new TemporaryFolder();
@@ -218,7 +218,7 @@ public abstract class AbstractServiceGenerationTest {
       for (Method expectedServiceMethod : testServiceClass
           .getDeclaredMethods()) {
         if (!Modifier.isPublic(expectedServiceMethod.getModifiers())
-            || securityChecker.getSecurityTarget(expectedServiceMethod)
+            || accessChecker.getSecurityTarget(expectedServiceMethod)
                 .isAnnotationPresent(DenyAll.class)) {
           continue;
         }
@@ -287,7 +287,7 @@ public abstract class AbstractServiceGenerationTest {
           expectedServiceMethod), apiResponse.getContent());
     }
 
-    if (securityChecker.getSecurityTarget(expectedServiceMethod)
+    if (accessChecker.getSecurityTarget(expectedServiceMethod)
         .isAnnotationPresent(AnonymousAllowed.class)) {
       assertNull(
           "Expected to have no security data for anonymous service method",

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/denyall/DenyAllService.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/denyall/DenyAllService.java
@@ -21,7 +21,7 @@ import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 
 import com.vaadin.connect.VaadinService;
-import com.vaadin.connect.oauth.AnonymousAllowed;
+import com.vaadin.connect.auth.AnonymousAllowed;
 
 @VaadinService
 @DenyAll

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/json/JsonTestService.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/json/JsonTestService.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.Version;
 import com.vaadin.connect.VaadinService;
-import com.vaadin.connect.oauth.AnonymousAllowed;
+import com.vaadin.connect.auth.AnonymousAllowed;
 
 /**
  * This class is used for OpenApi generator test

--- a/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/VaadinConnectControllerConfiguration.java
@@ -18,6 +18,7 @@ package com.vaadin.connect;
 
 import java.lang.reflect.Method;
 
+import com.vaadin.connect.auth.VaadinConnectAccessChecker;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -90,5 +91,15 @@ public class VaadinConnectControllerConfiguration {
   @Bean
   public VaadinServiceNameChecker serviceNameChecker() {
     return new VaadinServiceNameChecker();
+  }
+
+  /**
+   * Registers a default {@link VaadinConnectAccessChecker} bean instance.
+   *
+   * @return the default Vaadin Connect access checker bean
+   */
+  @Bean
+  public VaadinConnectAccessChecker accessChecker() {
+    return new VaadinConnectAccessChecker();
   }
 }

--- a/vaadin-connect/src/main/java/com/vaadin/connect/auth/AnonymousAllowed.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/auth/AnonymousAllowed.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  * security roles)</li>
  * </ul>
  *
- * @see VaadinConnectOAuthAclChecker for security rules check implementation
+ * @see VaadinConnectAccessChecker for security rules check implementation
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/vaadin-connect/src/main/java/com/vaadin/connect/auth/VaadinConnectAccessChecker.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/auth/VaadinConnectAccessChecker.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth;
 
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
@@ -35,7 +35,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.stereotype.Component;
 
 /**
  * Component used for checking role-based ACL in Vaadin Services.
@@ -78,8 +77,7 @@ import org.springframework.stereotype.Component;
  * </pre>
  *
  */
-@Component
-public class VaadinConnectOAuthAclChecker {
+public class VaadinConnectAccessChecker {
 
   /**
    * Check that the service is accessible for the current user.

--- a/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/EnableVaadinConnectOAuthServer.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/EnableVaadinConnectOAuthServer.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth.server;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -43,7 +43,6 @@ import org.springframework.stereotype.Component;
 @EnableAuthorizationServer
 @EnableResourceServer
 @Import({
-    VaadinConnectOAuthConfiguration.class,
-    VaadinConnectOAuthAclChecker.class })
+    VaadinConnectOAuthConfiguration.class })
 public @interface EnableVaadinConnectOAuthServer {
 }

--- a/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfiguration.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfiguration.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth.server;
 
 import java.util.Arrays;
 import java.util.List;

--- a/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfigurer.java
+++ b/vaadin-connect/src/main/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfigurer.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth.server;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;

--- a/vaadin-connect/src/test/java/com/vaadin/connect/VaadinConnectControllerTest.java
+++ b/vaadin-connect/src/test/java/com/vaadin/connect/VaadinConnectControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import com.vaadin.connect.oauth.VaadinConnectOAuthAclChecker;
+import com.vaadin.connect.auth.VaadinConnectAccessChecker;
 import com.vaadin.connect.testservice.BridgeMethodTestService;
 
 import static org.junit.Assert.assertEquals;
@@ -148,8 +148,8 @@ public class VaadinConnectControllerTest {
   public void should_Return404_When_IllegalAccessToMethodIsPerformed() {
     String accessErrorMessage = "Access error";
 
-    VaadinConnectOAuthAclChecker restrictingCheckerMock = mock(
-        VaadinConnectOAuthAclChecker.class);
+    VaadinConnectAccessChecker restrictingCheckerMock = mock(
+        VaadinConnectAccessChecker.class);
     when(restrictingCheckerMock.check(TEST_METHOD))
         .thenReturn(accessErrorMessage);
 
@@ -502,7 +502,7 @@ public class VaadinConnectControllerTest {
             new TestClassWithCustomServiceName()));
 
     VaadinConnectController vaadinConnectController = new VaadinConnectController(
-        new ObjectMapper(), mock(VaadinConnectOAuthAclChecker.class),
+        new ObjectMapper(), mock(VaadinConnectAccessChecker.class),
         mock(VaadinServiceNameChecker.class), contextMock);
     ResponseEntity<String> response = vaadinConnectController
         .serveVaadinService("CustomService", "testMethod",
@@ -522,7 +522,7 @@ public class VaadinConnectControllerTest {
         .thenReturn(mockJacksonProperties);
     when(mockJacksonProperties.getVisibility())
         .thenReturn(Collections.emptyMap());
-    new VaadinConnectController(null, mock(VaadinConnectOAuthAclChecker.class),
+    new VaadinConnectController(null, mock(VaadinConnectAccessChecker.class),
         mock(VaadinServiceNameChecker.class), contextMock);
 
     verify(contextMock, times(1)).getBean(ObjectMapper.class);
@@ -543,7 +543,7 @@ public class VaadinConnectControllerTest {
     when(mockJacksonProperties.getVisibility())
         .thenReturn(Collections.singletonMap(PropertyAccessor.ALL,
             JsonAutoDetect.Visibility.PUBLIC_ONLY));
-    new VaadinConnectController(null, mock(VaadinConnectOAuthAclChecker.class),
+    new VaadinConnectController(null, mock(VaadinConnectAccessChecker.class),
         mock(VaadinServiceNameChecker.class), contextMock);
 
     verify(contextMock, times(1)).getBean(ObjectMapper.class);
@@ -561,7 +561,7 @@ public class VaadinConnectControllerTest {
     exception.expect(IllegalStateException.class);
     exception.expectMessage("object mapper");
 
-    new VaadinConnectController(null, mock(VaadinConnectOAuthAclChecker.class),
+    new VaadinConnectController(null, mock(VaadinConnectAccessChecker.class),
         mock(VaadinServiceNameChecker.class), contextMock);
   }
 
@@ -584,35 +584,35 @@ public class VaadinConnectControllerTest {
   }
 
   private <T> VaadinConnectController createVaadinController(T service) {
-    VaadinConnectOAuthAclChecker oAuthAclCheckerMock = mock(
-        VaadinConnectOAuthAclChecker.class);
-    when(oAuthAclCheckerMock.check(TEST_METHOD)).thenReturn(null);
+    VaadinConnectAccessChecker accessCheckerMock = mock(
+        VaadinConnectAccessChecker.class);
+    when(accessCheckerMock.check(TEST_METHOD)).thenReturn(null);
 
     VaadinServiceNameChecker nameCheckerMock = mock(
         VaadinServiceNameChecker.class);
     when(nameCheckerMock.check(TEST_SERVICE_NAME)).thenReturn(null);
 
     return createVaadinController(service, new ObjectMapper(),
-        oAuthAclCheckerMock, nameCheckerMock);
+        accessCheckerMock, nameCheckerMock);
   }
 
   private <T> VaadinConnectController createVaadinController(T service,
       ObjectMapper vaadinServiceMapper) {
-    VaadinConnectOAuthAclChecker oAuthAclCheckerMock = mock(
-        VaadinConnectOAuthAclChecker.class);
-    when(oAuthAclCheckerMock.check(TEST_METHOD)).thenReturn(null);
+    VaadinConnectAccessChecker accessCheckerMock = mock(
+        VaadinConnectAccessChecker.class);
+    when(accessCheckerMock.check(TEST_METHOD)).thenReturn(null);
 
     VaadinServiceNameChecker nameCheckerMock = mock(
         VaadinServiceNameChecker.class);
     when(nameCheckerMock.check(TEST_SERVICE_NAME)).thenReturn(null);
 
     return createVaadinController(service, vaadinServiceMapper,
-        oAuthAclCheckerMock, nameCheckerMock);
+        accessCheckerMock, nameCheckerMock);
   }
 
   private <T> VaadinConnectController createVaadinController(T service,
       ObjectMapper vaadinServiceMapper,
-      VaadinConnectOAuthAclChecker oAuthAclChecker,
+      VaadinConnectAccessChecker accessChecker,
       VaadinServiceNameChecker serviceNameChecker) {
     Class<?> serviceClass = service.getClass();
     ApplicationContext contextMock = mock(ApplicationContext.class);
@@ -620,7 +620,7 @@ public class VaadinConnectControllerTest {
         .thenReturn(Collections.singletonMap(serviceClass.getName(), service));
     when(contextMock.getType(serviceClass.getName()))
         .thenReturn((Class) serviceClass);
-    return new VaadinConnectController(vaadinServiceMapper, oAuthAclChecker,
+    return new VaadinConnectController(vaadinServiceMapper, accessChecker,
         serviceNameChecker, contextMock);
   }
 }

--- a/vaadin-connect/src/test/java/com/vaadin/connect/auth/VaadinConnectAccessCheckerTest.java
+++ b/vaadin-connect/src/test/java/com/vaadin/connect/auth/VaadinConnectAccessCheckerTest.java
@@ -1,4 +1,4 @@
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth;
 
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
@@ -14,7 +14,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -29,7 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
-public class VaadinConnectOauthAclCheckerTest {
+public class VaadinConnectAccessCheckerTest {
   private static final String ROLE_USER = "ROLE_USER";
 
   @Rule
@@ -37,7 +36,7 @@ public class VaadinConnectOauthAclCheckerTest {
 
   private static SecurityContext securityContext;
 
-  private VaadinConnectOAuthAclChecker checker;
+  private VaadinConnectAccessChecker checker;
 
   public static class MockSecurityContextHolderStrategy
       implements SecurityContextHolderStrategy {
@@ -67,7 +66,7 @@ public class VaadinConnectOauthAclCheckerTest {
 
   @Before
   public void before() {
-    checker = new VaadinConnectOAuthAclChecker();
+    checker = new VaadinConnectAccessChecker();
 
     SecurityContextHolder
         .setStrategyName(MockSecurityContextHolderStrategy.class.getName());

--- a/vaadin-connect/src/test/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfigurerTest.java
+++ b/vaadin-connect/src/test/java/com/vaadin/connect/auth/server/VaadinConnectOAuthConfigurerTest.java
@@ -1,4 +1,4 @@
-package com.vaadin.connect.oauth;
+package com.vaadin.connect.auth.server;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/vaadin-connect/src/test/java/com/vaadin/connect/typeconversion/BaseTypeConversionIT.java
+++ b/vaadin-connect/src/test/java/com/vaadin/connect/typeconversion/BaseTypeConversionIT.java
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.vaadin.connect.VaadinConnectController;
 import com.vaadin.connect.VaadinServiceNameChecker;
-import com.vaadin.connect.oauth.VaadinConnectOAuthAclChecker;
+import com.vaadin.connect.auth.VaadinConnectAccessChecker;
 
 import static org.mockito.Mockito.mock;
 
@@ -49,7 +49,7 @@ public abstract class BaseTypeConversionIT {
   @Before
   public void setUp() {
     mockMvc = MockMvcBuilders.standaloneSetup(new VaadinConnectController(null,
-        mock(VaadinConnectOAuthAclChecker.class),
+        mock(VaadinConnectAccessChecker.class),
         mock(VaadinServiceNameChecker.class), applicationContext)).build();
     Assert.assertNotEquals(null, applicationContext);
   }


### PR DESCRIPTION
It should be possible to create an app with Vaadin Connect, that does not use the built-in OAuth server. The most trivial example of such an app would be one where anonymous access is allowed to all `@VaadinService`s.

The fix moves the access checker class closer to the core Vaadin Connect module, separating it from the OAuth server implementation class. The `@AnonymousAllowed` and `VaadinConnectAccessChecker` are in a different package from thedefault OAuth server because they can be used separately from it.

Fixes #242

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/319)
<!-- Reviewable:end -->
