### PR TITLE
docs: fix a typo in the path to `openapi.json` in 'Getting Started'

### DIFF
--- a/doc/getting-started.asciidoc
+++ b/doc/getting-started.asciidoc
@@ -53,7 +53,7 @@ single project.
 * `src/main/resources/application.properties` application properties
 * `src/test/java/` tests
 * `target` build directory
-** `target/generated/resources/openapi.json` generated OpenAPI specification
+** `target/generated-resources/openapi.json` generated OpenAPI specification
 
 .Frontend parts:
 * `package.json` npm project description and dependencies list


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/331)
<!-- Reviewable:end -->
