### PR TITLE
doc(typeconversion): update documentation for primitives, array, map

### DIFF
--- a/doc/type-conversion.asciidoc
+++ b/doc/type-conversion.asciidoc
@@ -6,134 +6,108 @@ layout: page
 
 = Vaadin Connect Type Conversion
 
-== JavaScript to Java [[from-js-to-java]]
+== TypeScript to Java [[from-ts-to-java]]
 
-When calling a Java service method from JavaScript, `ConnectClient` serializes JavaScript call parameters to JSON and sends them to Java backend where they are deserialized into Java types using the https://github.com/FasterXML/jackson[Jackson] JSON processing library. The return value of the Java service method is sent back to JavaScript through the same pipeline in the opposite direction.
+When calling a Java service method from TypeScript, `ConnectClient` serializes TypeScript call parameters to JSON and sends them to Java backend where they are deserialized into Java types using the https://github.com/FasterXML/jackson[Jackson] JSON processing library. The return value of the Java service method is sent back to TypeScript through the same pipeline in the opposite direction.
 
 The default Vaadin Connect JSON `ObjectMapper` closely follows the https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-json.html#boot-features-json-jackson[Spring Boot auto-configuration] defaults. One notable difference is that in Vaadin Connect the default object mapper is configured to discover `private` properties. I.e. all the fields, getters, setters or constructors are discoverable even if they are declared as `private`. This is done in order to make serialization / deserialization of custom objects easier.
 
 The visibility level of the default `ObjectMapper` can be configured by setting the `spring.jackson.visibility` property (in https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[common application properties]). Other properties of the default `ObjectMapper` can be customized by following the https://docs.spring.io/spring-boot/docs/current/reference/html/howto-spring-mvc.html#howto-customize-the-jackson-objectmapper[Spring Boot documentation] on the subject. Alternatively, the entire `ObjectMapper` can be replaced with a custom one by providing an `ObjectMapper` bean with the qualifier defined in `com.vaadin.connect.VaadinConnectController#VAADIN_SERVICE_MAPPER_BEAN_QUALIFIER`.
 
-The default `ObjectMapper` always converts JavaScript values to JSON object before sending them to the backend, so that the values need to be compliant with the JSON specification which only accepts values from the following types: `string`, `number`, `array`, `boolean`, JSON object or `null`. This implies that `undefined`, `NaN` and `Infinity` are non-compliant. If sent, the server will return an error response (`400 Bad Request`).
+The default `ObjectMapper` always converts TypeScript values to JSON object before sending them to the backend, so that the values need to be compliant with the JSON specification which only accepts values from the following types: `string`, `number`, `array`, `boolean`, JSON object or `null`. This implies that `undefined`, `NaN` and `Infinity` are non-compliant. If sent, the server will return an error response (`400 Bad Request`).
 
-The default conversion rules are summarized as follows (the JavaScript compliant values are converted to the corresponding values, otherwise the backend returns an error message):
+The default conversion rules are summarized as follows (the TypeScript compliant values are converted to the corresponding values, otherwise the backend returns an error message):
 
 === To receive primitive types in Java
 
 ==== Type `boolean`:
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** A boolean value: `true` => `true` and `false` => `false`
-** A boolean string (case sensitive): `"true"` => `true`, `"True"` => `true`, `"false"` => `false` and `"False"` => `false`
-** Any integer number different from zero are true: `1` => `true`, `-1` => `true` but `0` => `false`
-** `null` => `false`
 
 * Noncompliant values:
-** A boolean string with more than one first upper case letter: `"TRUE"`, `"TRue"`, `"FALSE"`, `"FAlse"` and other similar cases.
-** A decimal number: `100.0`
-** A non-boolean string: `"foo"`, `"100.9"`
-** Any other types: object or array
+** Any value that is not a valid `boolean` type in TypeScript.
 
 ==== Type `char`:
 
-* JavaScript compliant values:
-** A single character string: `"a"` => `'a'`
-** An integer from `0` to `2^16^ - 1`: `128` => unicode character `'\u0080'`
-** `null` => `0`
+* TypeScript compliant values:
+** A single character string: `'a'` => `'a'`
 
 * Noncompliant values:
-** A non single character string: `"fo"`, `"10"`
-** An integer number which is less than `0` or greater than `2^16^ - 1`
-** A decimal number
-** Any other types: boolean, object or array
+** Any string value that has more than one characters.
+** Any value that is not a valid `string` type in TypeScript.
 
-* UTF-16 and Unicode: Both Java and JavaScript internally use UTF-16 for string encoding. This makes string conversion between backend and frontend trivial. However, using UTF-16 has its limitations and corner cases. Most notably, a string like `"🥑"` might seem like a single-character which can be passed to Java as a `char`. However, both in JavaScript and Java it is actually a two-character string (because the `U+1F951` symbol takes 2 characters in UTF-16: `\uD83E\uDD51`). Thus, it is not a valid value for the Java `char` type.
+* UTF-16 and Unicode: Both Java and TypeScript internally use UTF-16 for string encoding. This makes string conversion between backend and frontend trivial. However, using UTF-16 has its limitations and corner cases. Most notably, a string like `"🥑"` might seem like a single-character which can be passed to Java as a `char`. However, both in TypeScript and Java it is actually a two-character string (because the `U+1F951` symbol takes 2 characters in UTF-16: `\uD83E\uDD51`). Thus, it is not a valid value for the Java `char` type.
 
 ==== Type `byte`:
 
-* JavaScript compliant values:
-** An integer or decimal number: `100`, `100.0` and `100.9` => `100`
-** An integer string: `"100"` => `100`
-** `null` => `0`
+* TypeScript compliant values:
+** An integer or decimal number in range of `-129 < X < 256`: `100`, `100.0` and `100.9` => `100`
 
 * Noncompliant values:
-** A non-integer string: `"foo"`, `"100.9"`
-** Any other types: boolean, object or array
+** Any value which is not a number in TypeScript.
+** Any number value which is out of the compliant range.
 
-* Overflow number: if JavaScript sends a value which is greater than Java's `Byte.MAX_VALUE` (2^8^ - 1), the bits gets rolled over. For example, sends a value `128` (`Byte.MAX_VALUE + 1`), Java side receives `-128` (`Byte.MIN_VALUE`).
 
-* Underflow number: if Java side expects a `byte` value but JavaScript sends an underflow number, e.g. `-129` (`Byte.MIN_VALUE - 1`), the backend returns an error.
+* Overflow number: if TypeScript sends a value which is greater than Java's `Byte.MAX_VALUE` (2^8^ - 1), the bits gets rolled over. For example, sends a value `128` (`Byte.MAX_VALUE + 1`), Java side receives `-128`(`Byte.MIN_VALUE`).
+
+* Underflow number: if Java side expects a `byte` value but TypeScript sends an underflow number, e.g. `-129` (`Byte.MIN_VALUE - 1`), the backend returns an error.
 
 ==== Type `short`:
 
-* JavaScript compliant values:
-** An integer or decimal number: `100`, `100.0` and `100.9` => `100`
-** An integer string: `"100"` => `100`
-** `null` => `0`
+* TypeScript compliant values:
+** An integer or decimal number in range of `-2^16^ < X < 2^16^ - 1`: `100`, `100.0` and `100.9` => `100`
 
 * Noncompliant values:
-** A multi-character string: `"fo"`, `"10"`
-** An integer number which is less than `0` or greater than `2^16^ - 1`
-** A decimal number
-** Any other types: boolean, object or array
+** Any value which is not a number in TypeScript.
+** Any number value which is out of the compliant range.
 
-* Overflow and underflow numbers are not acceptable for `short`
+* Overflow and underflow numbers are not accepted for `short`.
 
 ==== Type `int`:
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An integer or decimal number: `100`, `100.0` and `100.9` => `100`
-** An integer string: `"100"` => `100`
-** `null` => `0`
 
 * Noncompliant values:
-** A non-integer string: `"foo"`, `"100.9"`
-** Any other types: boolean, object, array
-** An overflow or underflow integer as a String: `"2147483648"`, `"-2147483649"`
+** Any value which is not a number in TypeScript.
 
-* Overflow number: if JavaScript sends a value which is greater than Java's `Integer.MAX_VALUE` (2^31^ - 1), the bits gets rolled over. For example, sending a value `2^31^` (`Integer.MAX_VALUE + 1`), Java side receives `-2^31^` (`Integer.MIN_VALUE`).
+* Overflow number: if TypeScript sends a value which is greater than Java's `Integer.MAX_VALUE` (2^31^ - 1), the bits gets rolled over. For example, sending a value `2^31^` (`Integer.MAX_VALUE + 1`), Java side receives `-2^31^` (`Integer.MIN_VALUE`).
 
 * Underflow number: it is vice versa with overflow number. Sending `-2^31^ - 1` (`Integer.MIN_VALUE - 1`), Java side gets `2^31^ - 1` (`Integer.MAX_VALUE`).
 
 ==== Type `long`:
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An integer or decimal number: `100`, `100.0` and `100.9` => `100`
-** An integer string: `"100"` => `100`
-** `null` => `0`
 
 * Noncompliant values:
-** A non-integer string: `"foo"`, `"100.9"`
-** Any other types: boolean, object or array
-** An overflow or underflow long as a String: `"9223372036854775808"`, `"-9223372036854775809"`
+** Any value which is not a number in TypeScript.
 
 * Overflow and underflow numbers: bits get rolled over when receiving overflow/underflow number i.e. `2^63^` => `-2^63^`, `-2^63^ - 1` => `2^63^ - 1`
 
 ==== Type `float` and `double`:
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An integer or decimal number: `100` and `100.0` => `100.0`, `100.9` => `100.9`
-** A number string: `"100"` => `100.0`, `"100.9"` => `100.9`
-** `null` => `0.0`
 
 * Noncompliant values:
-** A non-number string: `"foo"`
-** Any other types: boolean, object or array
+** Any value which is not a number in TypeScript.
 
 * Overflow and underflow numbers are converted to `Infinity` and `-Infinity` respectively.
 
 === To receive boxed primitive types in Java
 
-The conversion works the same as primitive type except that `null` is converted to `null` instead of default value.
+The conversion works the same as primitive type.
 
 === To receive a `String` in Java
 
-Any `String` values are kept the same when sent from JavaScript to Java backend.
+Any `String` values are kept the same when sent from TypeScript to Java backend.
 
 === To receive date time types in Java
 ==== java.util.Date
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An integer number or string that represents an epoch timestamp: `1546300800` or `"1546300800"` are converted to a `java.util.Date` instance which contains value of the date `01-01-2019`.
 
 * Noncompliant values:
@@ -142,7 +116,7 @@ Any `String` values are kept the same when sent from JavaScript to Java backend.
 
 ==== java.time.LocalDate
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** A string which follows the `java.time.format.DateTimeFormatter#ISO_LOCAL_DATE` format `yyyy-MM-dd`: `"2018-12-16"`, `"2019-01-01"`.
 
 * Noncompliant values:
@@ -151,7 +125,7 @@ Any `String` values are kept the same when sent from JavaScript to Java backend.
 
 ==== java.time.LocalDateTime
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** A string which follows the `java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME` format:
 *** With full time: `"2019-01-01T12:34:56"`
 *** Without seconds: `"2019-01-01T12:34"`
@@ -163,8 +137,8 @@ Any `String` values are kept the same when sent from JavaScript to Java backend.
 
 === To receive an `Enum` in Java
 
-* JavaScript compliant value:
-** A string with the same name as an enum: assume that we have an <<enum-declaration>>, then sending `"FIRST"` from JavaScript would result an instance of `FIRST` with `value=1` in Java.
+* TypeScript compliant value:
+** A string with the same name as an enum: assume that we have an <<enum-declaration>>, then sending `"FIRST"` from TypeScript would result an instance of `FIRST` with `value=1` in Java.
 
 .Enum declaration
 [source, java]
@@ -192,40 +166,35 @@ public enum TestEnum {
 
 === To receive an array in Java
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An array of items with expected type in Java, for example:
-*** Expected in Java `int[]`: `[1, 2, 3]` => `[1,2,3]`, `[1.9, 2, 3]` => `[1,2,3]`, `["1", 2, 3]` => `[1,2,3]`
-*** Expected in Java `String[]`: `["foo","bar"]` => `["foo","bar"]`, `["numberWorksForStringArray", 1, 2.0]` => `["numberWorksForStringArray", "1", "2.0"]`
+*** Expected in Java `int[]`: `[1, 2, 3]` => `[1,2,3]`, `[1.9, 2, 3]` => `[1,2,3]`
+*** Expected in Java `String[]`: `["foo","bar"]` => `["foo","bar"]`
 *** Expected in Java `Object[]`: `["foo", 1, null, "bar"]` => `["foo", 1, null, "bar"]`
 
 * Noncompliant values:
-** Mixed types array might not work: if you expected `int[]` in Java,  `["1.9", 2, 3]` won't work.
 ** A non-array input: `"foo"`, `"[1,2,3]"`, `1`
-** Any other types: boolean, object
 
 === To receive a collection in Java
 
-* JavaScript compliant values:
+* TypeScript compliant values:
 ** An array of items with expected type in Java (or types which can be converted to expected types), for example, if you expected in Java:
-*** `Collection<Integer>`: `[1, 2, 3]` => `[1,2,3]`, `["1","2","3"]` => `[1,2,3]`
+*** `Collection<Integer>`: `[1, 2, 3]` => `[1,2,3]`
 *** `Collection<String>`: `["foo","bar"]` => `["foo","bar"]`
-*** `Collection<Object>`: `["foo",1,null,"bar"]` => `["foo",1,null,"bar"]`
 *** `Set<Integer>`: `[1, 2, 2, 3, 3, 3]` => `[1, 2, 3]`
 
 * Noncompliant values:
 ** A non-array input: `"foo"`, `"[1,2,3]"`, `1`
-** Any other types: boolean, object
 
 === To receive a map in Java
 
-* JavaScript compliant value:
-** An object with string keys and values with the expected type in Java:
-*** `Map<String, String>`: `{"key1": "1", "key2": "2"}` => `{"key1": "1", "key2": "2"}`, `{"integerValue": 1, "alsoValidForStringMap": 2}` => `{"integerValue": "1", "alsoValidForStringMap": "2"}`
-*** `Map<String, TestEnum>`: `{"key1": "FIRST", "key2": "SECOND"}` => `{"key1": "FIRST", "key2": "SECOND"}`
-*** Enum could be used as keys of a map `Map<TestEnum, Integer>`: `{"FIRST": 1, "SECOND": 2}` => `{"FIRST": 1, "SECOND": 2}`
+* TypeScript compliant value:
+** A `Map` instance in TypeScript with string keys and values with the expected type in Java.
 
 * Noncompliant values:
-** Any non-object types: number, string, boolean or array.
+** Any value from other types.
+
+NOTE: Due to the fact that the TypeScript code is generated from OpenAPI (<<typescript-generator#,TypeScript Services Generator>>) and the OpenAPI specification has https://swagger.io/docs/specification/data-models/dictionaries/[a limitation for map type], the map key is always a `string` in TypeScript.
 
 === To receive a bean in Java
 
@@ -265,44 +234,49 @@ public class MyBean {
 }
 ----
 
-== Java to JavaScript
+== Java to TypeScript
 
-The same object mapper used when converting from <<from-js-to-java>> deserializes the return values in Java to the corresponding JSON object before sending them to client-side.
+The same object mapper used when converting from <<from-ts-to-java>> deserializes the return values in Java to the corresponding JSON object before sending them to client-side.
 
 === Type `number`
 
-All the Java types which extend `java.lang.Number` are deserialized to `number` in JavaScript. There are a few exceptional cases with extremely large or small numbers. The safe integer range is from `-(2^53^ - 1)` to `2^53^ - 1`. It means only numbers in this range can be represented exactly and correctly compared them (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger[more information about safe integer]).
+All the Java types which extend `java.lang.Number` are deserialized to `number` in TypeScript. There are a few exceptional cases with extremely large or small numbers. The safe integer range is from `-(2^53^ - 1)` to `2^53^ - 1`. It means only numbers in this range can be represented exactly and correctly compared them (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger[more information about safe integer]).
 
-Practically, not all `long` number in Java can be converted correctly in JavaScript since its range is `-2^63^` to `2^63^ - 1`. The unsafe numbers are rounded using the rules defined in https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules[IEEE-754 standard].
+Practically, not all `long` number in Java can be converted correctly in TypeScript since its range is `-2^63^` to `2^63^ - 1`. The unsafe numbers are rounded using the rules defined in https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules[IEEE-754 standard].
 
-The special values such as `NaN`, `POSITIVE_INFINITY` and `NEGATIVE_INFINITY` are converted into `string` when sent to JavaScript.
+The special values such as `NaN`, `POSITIVE_INFINITY` and `NEGATIVE_INFINITY` are converted into `string` when sent to TypeScript.
 
 === Type `string`
 
-The primitive type `char`, its boxed type `Character` and `String` in Java are converted to `string` type in JavaScript.
+The primitive type `char`, its boxed type `Character` and `String` in Java are converted to `string` type in TypeScript.
 
 === Type `boolean`
 
-`boolean` and `Boolean` in Java are converted to `boolean` type when received in JavaScript.
+`boolean` and `Boolean` in Java are converted to `boolean` type when received in TypeScript.
 
 === Array of items
 
-All the types which implement or extend `java.lang.Collection` becomes `array` when they are sent to JavaScript.
+Normal array types such as `int[]`, `MyBean[]` and all the types which implement or extend `java.lang.Collection` becomes `array` when they are sent to TypeScript.
 
-=== Object and map
+=== Object
 
-Any kinds of objects and maps in Java are converted to `object` in JavaScript. The objects hold property-value pairs which can be accessed by either ways `object.property` or `object["property"]`.
+Any kinds of objects in Java are converted to corresponding defined types in TypeScript. For example, if your service methods returns a `MyBean` type, so when you called the method, you will receive an object in type of `MyBean`. In case of the generator can't get information about your bean, it returns an object in `any`.
+
+=== Map
+
+All types which inherit from `java.lang.Map` becomes TypeScript `Map`.
 
 === Datetime
 
-By default, the `ObjectMapper` converts Java's date time to a string in JavaScript with the following formats:
+By default, the `ObjectMapper` converts Java's date time to a string, then it will be wrapped into a `Date` object in TypeScript:
 
-* `java.util.Date` of `00:00:00 January 1st, 2019` => `"2019-01-01T00:00:00.000+0000"`
+* A `java.util.Date` or `java.time.Instant` object of `January 1st, 2019 02:00:00 UTC` => a `Date` object of the corresponding time depending on the browser's locale, e.g.  `January 1st, 2019 04:00:00 GTM+2` or  `December 31st, 2018 18:00:00 GTM-8`
 
-* `java.time.LocalDate` of `00:00:00 January 1st, 2019` => `"2019-01-01"`
+* A `java.time.LocalDate` object of `January 1st, 2019` => a `Date` object of `January 1st, 2019` regardless the browser's locale.
 
-* `java.time.LocalDateTime` of `00:00:00 January 1st, 2019` => `"2019-01-01T00:00:00"`
+* A `java.time.LocalDateTime` object of `January 1st, 2019 02:00:00` => a `Date` object of `January 1st, 2019 02:00:00` regardless the browser's locale.
+
 
 === `null`
 
-If the backend returns `null`, it is also `null` in JavaScript.
+If the backend returns `null`, it is also `null` in TypeScript.


### PR DESCRIPTION
This PR updated information for:
- Primitive types
- String
- Array + collection
- Map (need to verify after implementation is done in #341 )
- Date (need to verify after implementation is done in #337 )

Enum has not generated properly (see #350) so it's better to fix doc in that issue as well.
Fixes #309  
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/346)
<!-- Reviewable:end -->
