### PR TITLE
test(plugin): verify that fields in services are not generated

### DIFF
--- a/vaadin-connect-demo/e2e/demo.spec.ts
+++ b/vaadin-connect-demo/e2e/demo.spec.ts
@@ -168,7 +168,12 @@ describe('demo application', () => {
       });
 
       it('should serialize/deserialize Date object', async() => {
-        await page.findById('dateTimeInput').clearValue().type('1546300800000').end().findById('echoDate').click();
+        await page
+          .findById('dateTimeInput')
+          .clearValue().type('1546300800000')
+          .end()
+          .findById('echoDate')
+          .click();
         // tslint:disable-next-line:only-arrow-functions
         await pollUntilTruthy(function(text) {
           return (
@@ -178,7 +183,11 @@ describe('demo application', () => {
       });
 
       it('should serialize/deserialize Instant object', async() => {
-        await page.findById('dateTimeInput').clearValue().type('1551886875').end().findById('echoInstant').click();;
+        await page
+          .findById('dateTimeInput')
+          .clearValue().type('1551886875')
+          .end()
+          .findById('echoInstant').click();
         // tslint:disable-next-line:only-arrow-functions
         await pollUntilTruthy(function(text) {
           return (
@@ -188,7 +197,12 @@ describe('demo application', () => {
       });
 
       it('should serialize/deserialize LocalDate object', async() => {
-        await page.findById('dateTimeInput').clearValue().type('2019-06-03').end().findById('echoLocalDate').click();
+        await page
+          .findById('dateTimeInput')
+          .clearValue().type('2019-06-03')
+          .end()
+          .findById('echoLocalDate')
+          .click();
         // tslint:disable-next-line:only-arrow-functions
         await pollUntilTruthy(function(text) {
           return (
@@ -198,7 +212,12 @@ describe('demo application', () => {
       });
 
       it('should serialize/deserialize LocalDateTime object', async() => {
-        await page.findById('dateTimeInput').clearValue().type('2019-01-01T12:34:56.78').end().findById('echoLocalDateTime').click();;
+        await page
+          .findById('dateTimeInput')
+          .clearValue().type('2019-01-01T12:34:56.78')
+          .end()
+          .findById('echoLocalDateTime')
+          .click();
         // tslint:disable-next-line:only-arrow-functions
         await pollUntilTruthy(function(text) {
           return (

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/model/ModelService.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/model/ModelService.java
@@ -29,6 +29,11 @@ import com.vaadin.connect.plugin.generator.services.model.subpackage.ModelFromDi
 public class ModelService {
 
   /**
+   * This field is irrelevant and the type shouldn't be generated.
+   */
+  private ShouldNotBeGenerated thisFieldShouldNotBeGenerated;
+
+  /**
    * Get account by username.
    * 
    * @param userName

--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/model/ShouldNotBeGenerated.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/model/ShouldNotBeGenerated.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.connect.plugin.generator.services.model;
+
+/**
+ * This class should not be generated at all.
+ */
+public class ShouldNotBeGenerated {
+  String foo;
+  int bar;
+}


### PR DESCRIPTION
Fixes #339.
Apparently, this PR doesn't fix the issue since it is not reproducible in the current state of the plugin (possibly fixed in #317). But I added a field into a test to make sure it won't happen again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/357)
<!-- Reviewable:end -->
