### PR TITLE
fix(scripts): Run watcher as the last one

### DIFF
--- a/frontend/connect-scripts/src/commands/start.ts
+++ b/frontend/connect-scripts/src/commands/start.ts
@@ -10,9 +10,9 @@ import {command as webpackCommand} from './start/webpack';
 
 export const command: Command = async() => {
   await useCommand(backendCommand);
-  await useCommand(javaWatcherCommand);
   await useCommand(apiBrowserCommand);
   await useCommand(webpackCommand);
+  await useCommand(javaWatcherCommand);
 
   return new Promise<void>(_ => {
     // Never resolves to keep Node.js waiting for an interrupt


### PR DESCRIPTION
Closes https://github.com/vaadin/base-starter-connect/issues/80

For some strange reason, file watcher fails to be stopped when the situation as the one described in a ticket happens.
I've investigated and it seems that the logic is correct — we store the correct pid for the watcher and use it to kill the process, the process kill happens without any error but does not actually kill the watcher process.
The order of the processes did not matter also — as long as there's an error happening, the watcher is not stopped even though the `kill(watcherProcess.pid);` code is executed.
When there's no error, the watcher seems to be stopped correctly.

Considering all this, I've moved the watcher start to the very end, after all port-dependent processes are launched — this allows us not to start the watcher if any error happens before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/358)
<!-- Reviewable:end -->
