### PR TITLE
fix(client): allow falsy return from credentials callback

### DIFF
--- a/frontend/connect/src/connect-client.ts
+++ b/frontend/connect/src/connect-client.ts
@@ -303,7 +303,7 @@ export interface CredentialsCallbackOptions {
  * @param options
  */
 export type CredentialsCallback = (options?: CredentialsCallbackOptions) =>
-  Promise<Credentials> | Credentials;
+  Promise<Credentials | undefined> | Credentials | undefined;
 
 /**
  * The `ConnectClient` constructor options.


### PR DESCRIPTION
Update the TS type definition for the credentials callback so that `undefined` is an allowed return value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/368)
<!-- Reviewable:end -->
