### PR TITLE
fix(generator): generate correct import paths on Windows / part 2

### DIFF
--- a/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
+++ b/vaadin-connect-maven-plugin/src/main/java/com/vaadin/connect/plugin/generator/VaadinConnectTsGenerator.java
@@ -606,7 +606,7 @@ public class VaadinConnectTsGenerator extends AbstractTypeScriptClientCodegen {
 
   private void adjustImportInformationForServices(
       List<Map<String, Object>> imports) {
-    adjustImportInformation(imports, "");
+    adjustImportInformation(imports, ".");
   }
 
   private void adjustImportInformationForModel(


### PR DESCRIPTION
Amends the partial fix done in https://github.com/vaadin/vaadin-connect/pull/393
Fixes #391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-connect/395)
<!-- Reviewable:end -->
