### PR TITLE
Fix issue #388

### DIFF
--- a/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/notnull/NotNullService.java
+++ b/vaadin-connect-maven-plugin/src/test/java/com/vaadin/connect/plugin/generator/services/notnull/NotNullService.java
@@ -17,6 +17,7 @@ package com.vaadin.connect.plugin.generator.services.notnull;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,8 +45,16 @@ public class NotNullService {
     return new ReturnType();
   }
 
+  @NotNull
+  public Collection<@NotNull ReturnType> getNotNullGenericParameterType() {
+    return Collections.singleton(new ReturnType());
+  }
+
   public void sendParameterType(
       @NotNull NotNullService.ParameterType parameterType) {
+  }
+
+  public void sendNotNullGenericParameterType(@NotNull Collection<@NotNull ParameterType> collection) {
 
   }
 

--- a/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/notnull/expected-NotNullService.ts
+++ b/vaadin-connect-maven-plugin/src/test/resources/com/vaadin/connect/plugin/generator/services/notnull/expected-NotNullService.ts
@@ -22,8 +22,18 @@ export function getNonNullString(
   return client.call('NotNullService', 'getNonNullString', {input});
 }
 
+export function getNotNullGenericParameterType(): Promise<Array<ReturnType>> {
+  return client.call('NotNullService', 'getNotNullGenericParameterType');
+}
+
 export function getNotNullReturnType(): Promise<ReturnType> {
   return client.call('NotNullService', 'getNotNullReturnType');
+}
+
+export function sendNotNullGenericParameterType(
+  collection: Array<ParameterType>
+): Promise<void> {
+  return client.call('NotNullService', 'sendNotNullGenericParameterType', {collection});
 }
 
 export function sendParameterType(


### PR DESCRIPTION
Fixes issue #388 for collections.

The ComposedSchema part of `setNullableByNotNullAnnotations` is not currently useful, as for e.g. a custom bean, the generic parameter is not included in the generated typescript.

Perhaps it will be useful at some point in the future, however.